### PR TITLE
Extract pyethapp and push to dockerhub

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,13 @@ init-config:
 	sh start.sh
 	cp docker-compose.default.yml docker-compose.yml
 
+build-pyethapp:
+	docker build -t ethresearch/pyethapp ./pyethapp
+
+push-pyethapp:
+	docker login
+	docker push ethresearch/pyethapp
+
 init-source:
 	mkdir shared_data
 	test -d ./shared_data/pydevp2p || git clone https://github.com/ethereum/pydevp2p.git --branch develop ./shared_data/pydevp2p

--- a/bootstrap/Dockerfile
+++ b/bootstrap/Dockerfile
@@ -1,35 +1,4 @@
-FROM ubuntu:16.04
-ENV LANG C.UTF-8
-ENV LC_ALL C.UTF-8
-
-# Install system dependencies
-RUN apt-get update
-RUN apt-get install -y software-properties-common vim git git-core iputils-ping
-RUN add-apt-repository -y ppa:jonathonf/python-3.6
-RUN add-apt-repository -y ppa:ethereum/ethereum
-RUN apt-get update
-RUN apt-get install -y solc
-RUN apt-get install -y build-essential python3.6 python3.6-dev python3-pip python3.6-venv
-RUN apt-get install -y libssl-dev build-essential automake pkg-config libtool libffi-dev libgmp-dev
-RUN apt-get install -y git
-
-# Install Python dependencies
-RUN python3.6 -m pip install pip --upgrade
-RUN python3.6 -m pip install wheel
-RUN ln -sf /usr/local/bin/pip3.6 /usr/local/bin/pip \
-    && ln -sf /usr/bin/python3.6 /usr/local/bin/python \
-    && pip install -U pip
-RUN pip install coincurve==6.0.0
-
-# Clone and install (editable) required repositories
-RUN mkdir /ethereum
-WORKDIR /ethereum
-RUN git clone https://github.com/ethereum/viper.git
-RUN git clone  --recursive https://github.com/karlfloersch/pyethereum.git
-RUN git clone https://github.com/karlfloersch/pyethapp.git
-RUN cd viper && python setup.py develop
-RUN cd pyethapp && python setup.py develop
-RUN cd pyethereum && python setup.py develop
+FROM ethresearch/pyethapp
 
 COPY data/config /root/.config/pyethapp
 COPY data/log /root/log

--- a/miner/Dockerfile
+++ b/miner/Dockerfile
@@ -1,35 +1,4 @@
-FROM ubuntu:16.04
-ENV LANG C.UTF-8
-ENV LC_ALL C.UTF-8
-
-# Install system dependencies
-RUN apt-get update
-RUN apt-get install -y software-properties-common vim git git-core iputils-ping
-RUN add-apt-repository -y ppa:jonathonf/python-3.6
-RUN add-apt-repository -y ppa:ethereum/ethereum
-RUN apt-get update
-RUN apt-get install -y solc
-RUN apt-get install -y build-essential python3.6 python3.6-dev python3-pip python3.6-venv
-RUN apt-get install -y libssl-dev build-essential automake pkg-config libtool libffi-dev libgmp-dev
-RUN apt-get install -y git
-
-# Install Python dependencies
-RUN python3.6 -m pip install pip --upgrade
-RUN python3.6 -m pip install wheel
-RUN ln -sf /usr/local/bin/pip3.6 /usr/local/bin/pip \
-    && ln -sf /usr/bin/python3.6 /usr/local/bin/python \
-    && pip install -U pip
-RUN pip install coincurve==6.0.0
-
-# Clone and install (editable) required repositories
-RUN mkdir /ethereum
-WORKDIR /ethereum
-RUN git clone https://github.com/ethereum/viper.git
-RUN git clone  --recursive https://github.com/karlfloersch/pyethereum.git
-RUN git clone https://github.com/karlfloersch/pyethapp.git
-RUN cd viper && python setup.py develop
-RUN cd pyethapp && python setup.py develop
-RUN cd pyethereum && python setup.py develop
+FROM ethresearch/pyethapp
 
 COPY data/config /root/.config/pyethapp
 COPY data/log /root/log

--- a/pyethapp/Dockerfile
+++ b/pyethapp/Dockerfile
@@ -1,0 +1,32 @@
+FROM ubuntu:16.04
+ENV LANG C.UTF-8
+ENV LC_ALL C.UTF-8
+
+# Install system dependencies
+RUN apt-get update &&\
+    apt-get install -y software-properties-common vim git iputils-ping
+RUN add-apt-repository -y ppa:jonathonf/python-3.6
+RUN add-apt-repository -y ppa:ethereum/ethereum
+RUN apt-get update &&\
+    apt-get install -y solc build-essential python3.6 python3.6-dev python3-pip \
+    python3.6-venv libssl-dev build-essential automake pkg-config libtool libffi-dev libgmp-dev
+
+
+# Install Python dependencies
+RUN python3.6 -m pip install pip --upgrade
+RUN python3.6 -m pip install wheel
+RUN ln -sf /usr/local/bin/pip3.6 /usr/local/bin/pip \
+    && ln -sf /usr/bin/python3.6 /usr/local/bin/python \
+    && pip install -U pip
+RUN pip install coincurve==6.0.0 web3
+
+# Clone and install (editable) required repositories
+WORKDIR /ethereum
+RUN git clone https://github.com/ethereum/viper.git
+RUN git clone https://github.com/karlfloersch/pyethereum.git &&\
+    cd pyethereum && git submodule update --init casper
+RUN git clone https://github.com/karlfloersch/pyethapp.git
+RUN cd viper && python setup.py develop
+RUN cd pyethapp && python setup.py develop
+RUN cd pyethereum && python setup.py develop
+

--- a/validator/Dockerfile
+++ b/validator/Dockerfile
@@ -3,15 +3,14 @@ ENV LANG C.UTF-8
 ENV LC_ALL C.UTF-8
 
 # Install system dependencies
-RUN apt-get update
-RUN apt-get install -y software-properties-common vim git git-core iputils-ping
+RUN apt-get update &&\
+    apt-get install -y software-properties-common vim git iputils-ping
 RUN add-apt-repository -y ppa:jonathonf/python-3.6
 RUN add-apt-repository -y ppa:ethereum/ethereum
-RUN apt-get update
-RUN apt-get install -y solc
-RUN apt-get install -y build-essential python3.6 python3.6-dev python3-pip python3.6-venv
-RUN apt-get install -y libssl-dev build-essential automake pkg-config libtool libffi-dev libgmp-dev
-RUN apt-get install -y git
+RUN apt-get update &&\
+    apt-get install -y solc build-essential python3.6 python3.6-dev python3-pip \
+    python3.6-venv libssl-dev build-essential automake pkg-config libtool libffi-dev libgmp-dev
+
 
 # Install Python dependencies
 RUN python3.6 -m pip install pip --upgrade
@@ -19,14 +18,13 @@ RUN python3.6 -m pip install wheel
 RUN ln -sf /usr/local/bin/pip3.6 /usr/local/bin/pip \
     && ln -sf /usr/bin/python3.6 /usr/local/bin/python \
     && pip install -U pip
-RUN pip install coincurve==6.0.0
-RUN pip install web3
+RUN pip install coincurve==6.0.0 web3
 
 # Clone and install (editable) required repositories
-RUN mkdir /ethereum
 WORKDIR /ethereum
 RUN git clone https://github.com/ethereum/viper.git
-RUN git clone  --recursive https://github.com/karlfloersch/pyethereum.git
+RUN git clone https://github.com/karlfloersch/pyethereum.git &&\
+    cd pyethereum && git submodule update --init casper
 RUN git clone https://github.com/karlfloersch/pyethapp.git
 RUN cd viper && python setup.py develop
 RUN cd pyethapp && python setup.py develop

--- a/validator/Dockerfile
+++ b/validator/Dockerfile
@@ -1,34 +1,5 @@
-FROM ubuntu:16.04
-ENV LANG C.UTF-8
-ENV LC_ALL C.UTF-8
+FROM ethresearch/pyethapp
 
-# Install system dependencies
-RUN apt-get update &&\
-    apt-get install -y software-properties-common vim git iputils-ping
-RUN add-apt-repository -y ppa:jonathonf/python-3.6
-RUN add-apt-repository -y ppa:ethereum/ethereum
-RUN apt-get update &&\
-    apt-get install -y solc build-essential python3.6 python3.6-dev python3-pip \
-    python3.6-venv libssl-dev build-essential automake pkg-config libtool libffi-dev libgmp-dev
-
-
-# Install Python dependencies
-RUN python3.6 -m pip install pip --upgrade
-RUN python3.6 -m pip install wheel
-RUN ln -sf /usr/local/bin/pip3.6 /usr/local/bin/pip \
-    && ln -sf /usr/bin/python3.6 /usr/local/bin/python \
-    && pip install -U pip
-RUN pip install coincurve==6.0.0 web3
-
-# Clone and install (editable) required repositories
-WORKDIR /ethereum
-RUN git clone https://github.com/ethereum/viper.git
-RUN git clone https://github.com/karlfloersch/pyethereum.git &&\
-    cd pyethereum && git submodule update --init casper
-RUN git clone https://github.com/karlfloersch/pyethapp.git
-RUN cd viper && python setup.py develop
-RUN cd pyethapp && python setup.py develop
-RUN cd pyethereum && python setup.py develop
 
 COPY data/config /root/.config/pyethapp
 COPY data/log /root/log


### PR DESCRIPTION
In this PR, I did the following:

- Extract common component from bootstrap, miner, validator nodes to pyethapp.
- Slimming down pyethapp: from 1.59GB to 794MB. This is achieved via not cloning the fixtures repo.
- Push pyethapp to Docker Hub, see [ethresearch/pyethapp](https://hub.docker.com/r/ethresearch/pyethapp/). When running `docker-compose build`, the image will be pulled from the hub. You can also build ethresearch/pyethapp via `make build-pyethapp`. 

![](https://i.imgur.com/mveB8xJ.jpg)