### PR TITLE
Better RPC config

### DIFF
--- a/miner/data/config/config.yaml
+++ b/miner/data/config/config.yaml
@@ -55,6 +55,7 @@ eth:
     }
   }
 jsonrpc:
+  listen_host: '0.0.0.0'
   listen_port: 8545
 discovery:
   listen_port: 30303

--- a/validator/data/config/config.yaml
+++ b/validator/data/config/config.yaml
@@ -55,6 +55,7 @@ eth:
     }
   }
 jsonrpc:
+  listen_host: '0.0.0.0'
   listen_port: 8545
 discovery:
   listen_port: 30303


### PR DESCRIPTION
### what's wrong
in the current config, rpc is by default listening to localhost, which means web3 requests from outside the container are not available.

### what is fixed

listen host to 0.0.0.0

this enable setting up netstats easier