### PR TITLE
Updated filebeat.yml to receive error msg only

### DIFF
--- a/bootstrap/filebeat.yml
+++ b/bootstrap/filebeat.yml
@@ -3,7 +3,7 @@ filebeat.prospectors:
   enabled: true
   paths:
     - /root/log/*
-  exclude_lines: ["^INFO", "WARNING"]
+  exclude_lines: ["^INFO", "^WARNING", "^TRACE", "^DEBUG"]
 
 # Filebeat modules
 filebeat.config.modules:
@@ -13,4 +13,4 @@ filebeat.config.modules:
 
 # Logstash
 output.logstash:
-  hosts: ["54.210.166.201:5000"]
+  hosts: ["54.210.221.136:5000"]

--- a/bootstrap/filebeat.yml
+++ b/bootstrap/filebeat.yml
@@ -3,6 +3,7 @@ filebeat.prospectors:
   enabled: true
   paths:
     - /root/log/*
+  exclude_lines: ["^INFO", "WARNING"]
 
 # Filebeat modules
 filebeat.config.modules:

--- a/miner/filebeat.yml
+++ b/miner/filebeat.yml
@@ -3,7 +3,7 @@ filebeat.prospectors:
   enabled: true
   paths:
     - /root/log/*
-  exclude_lines: ["^INFO", "WARNING"]    
+  exclude_lines: ["^INFO", "WARNING", "TRACE", "DEBUG"]
 
 # Filebeat modules
 filebeat.config.modules:
@@ -13,4 +13,4 @@ filebeat.config.modules:
 
 # Logstash
 output.logstash:
-  hosts: ["54.210.166.201:5000"]
+  hosts: ["54.210.221.136:5000"]

--- a/miner/filebeat.yml
+++ b/miner/filebeat.yml
@@ -3,6 +3,7 @@ filebeat.prospectors:
   enabled: true
   paths:
     - /root/log/*
+  exclude_lines: ["^INFO", "WARNING"]    
 
 # Filebeat modules
 filebeat.config.modules:

--- a/validator/filebeat.yml
+++ b/validator/filebeat.yml
@@ -3,7 +3,7 @@ filebeat.prospectors:
   enabled: true
   paths:
     - /root/log/*
-  exclude_lines: ["^INFO", "WARNING"]
+  exclude_lines: ["^INFO", "WARNING", "TRACE", "DEBUG"]
 
 # Filebeat modules
 filebeat.config.modules:
@@ -13,4 +13,4 @@ filebeat.config.modules:
 
 # Logstash
 output.logstash:
-  hosts: ["54.210.166.201:5000"]
+  hosts: ["54.210.221.136:5000"]

--- a/validator/filebeat.yml
+++ b/validator/filebeat.yml
@@ -3,6 +3,7 @@ filebeat.prospectors:
   enabled: true
   paths:
     - /root/log/*
+  exclude_lines: ["^INFO", "WARNING"]
 
 # Filebeat modules
 filebeat.config.modules:


### PR DESCRIPTION
### What was wrong?

Too many messages were sent to Kibana with Filebeat

### How was it fixed?

Update `filebeat.yaml` with the following line to get rid of `INFO` and `WARNING` msgs
```yml
exclude_lines: ["^INFO", "WARNING"]
```