### PR TITLE
update readme.md to fix run-node network_name param and clarify faucet

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -75,9 +75,10 @@ $ make new-account
 
 Then send yourself some ETH with the faucet_util.py:
 ```
+$ docker cp utils/faucet_util.py bootstrap:/ethereum/
 $ docker exec -it bootstrap bash
 $ # Logs into docker container
-$$ python $FAUCET_PRIV_KEY $YOUR_ADDRESS $localhost
+$$ python faucet_util.py $FAUCET_PRIV_KEY $YOUR_ADDRESS localhost
 $$ # Check that the transaction worked with
 $$ python
 > from web3 import Web3, HTTPProvider
@@ -89,10 +90,10 @@ $$ python
 
 Login to the network with your validator by running:
 ```
-$ make run-node validate=true deposit=5000 network=dockerpyethdev_back bootstrap_node=enode://d3260a710a752b926bb3328ebe29bfb568e4fb3b4c7ff59450738661113fb21f5efbdf42904c706a9f152275890840345a5bc990745919eeb2dfc2c481d778ee@172.18.250.2:30303
+$ make run-node validate=true deposit=5000 network_name=dockerpyethdev_back bootstrap_node=enode://d3260a710a752b926bb3328ebe29bfb568e4fb3b4c7ff59450738661113fb21f5efbdf42904c706a9f152275890840345a5bc990745919eeb2dfc2c481d778ee@172.18.250.2:30303
 ```
 
 You can then stop your validator and logout with:
 ```
-$ make run-node validate=true logout=true network=dockerpyethdev_back bootstrap_node=enode://d3260a710a752b926bb3328ebe29bfb568e4fb3b4c7ff59450738661113fb21f5efbdf42904c706a9f152275890840345a5bc990745919eeb2dfc2c481d778ee@172.18.250.2:30303
+$ make run-node validate=true logout=true network_name=dockerpyethdev_back bootstrap_node=enode://d3260a710a752b926bb3328ebe29bfb568e4fb3b4c7ff59450738661113fb21f5efbdf42904c706a9f152275890840345a5bc990745919eeb2dfc2c481d778ee@172.18.250.2:30303
 ```


### PR DESCRIPTION
## What was wrong?
* Instructions to run faucet_util.py were slightly confusing
* `make run-node network=` was attempting to use the network as the docker image
## How was it fixed?
* Add command to copy faucet_util.py to boostrap container
* Update readme to include faucet_util.py in command, and remove $ from localhost
* Update readme to use `network_name` instead of `network`